### PR TITLE
display number and extra info for each event

### DIFF
--- a/comps/templates/comps/heat.html
+++ b/comps/templates/comps/heat.html
@@ -23,18 +23,18 @@
     </div>
     <div class="col-8">
       {% if forloop.counter == 1 %}
-        <h3 class="text-center d-none d-lg-block">{{ item.heat.get_category_display }} {{ item.heat.heat_number}}{{item.heat.extra}}: {{ item.heat.time }}</h3>
-        <h4 class="text-center d-block d-lg-none">{{ item.heat.get_category_display }} {{ item.heat.heat_number}}{{item.heat.extra}}: {{ item.heat.time }}</h4>
+        <h3 class="text-center d-none d-lg-block">{{ item.heat.time }}</h3>
+        <h4 class="text-center d-block d-lg-none">{{ item.heat.time }}</h4>
       {% endif %}
       {% if show_edit_button %}
-        <h4 class="text-center d-none d-lg-block mt-3">{{ item.heat.info }} <a href="{% url 'comps:edit_heat' item.heat.id %}" class="badge badge-link">Edit</a></h4>
-        <h5 class="text-center d-block d-lg-none mt-3">{{ item.heat.info }} <a href="{% url 'comps:edit_heat' item.heat.id %}" class="badge badge-link">Edit</a></h5>
+        <h4 class="text-center d-none d-lg-block mt-3">{{ item.heat.get_category_display }} {{ item.heat.heat_number}}{{item.heat.extra}}: {{ item.heat.info }} <a href="{% url 'comps:edit_heat' item.heat.id %}" class="badge badge-link">Edit</a></h4>
+        <h5 class="text-center d-block d-lg-none mt-3">{{ item.heat.get_category_display }} {{ item.heat.heat_number}}{{item.heat.extra}}: {{ item.heat.info }} <a href="{% url 'comps:edit_heat' item.heat.id %}" class="badge badge-link">Edit</a></h5>
         {% if item.error %}
           <p class="text-center bg-warning mt-0">{{ item.error.get_error_display }}</p>
         {% endif %}
       {% else %}
-        <h4 class="text-center d-none d-lg-block mt-3">{{ item.heat.info }}</h4>
-        <h5 class="text-center d-block d-lg-none mt-3">{{ item.heat.info }}</h5>
+        <h4 class="text-center d-none d-lg-block mt-3">{{ item.heat.get_category_display }} {{ item.heat.heat_number}}{{item.heat.extra}}: {{ item.heat.info }}</h4>
+        <h5 class="text-center d-block d-lg-none mt-3">{{ item.heat.get_category_display }} {{ item.heat.heat_number}}{{item.heat.extra}}: {{ item.heat.info }}</h5>
       {% endif %}
     </div>
     <div class="col-2">

--- a/comps/views/heat.py
+++ b/comps/views/heat.py
@@ -12,8 +12,8 @@ def heat(request, heat_id):
 
     heat = get_object_or_404(Heat, pk=heat_id)
 
-    # get all heats that match this category and time of day
-    parallel_heats = Heat.objects.filter(comp=heat.comp).filter(category=heat.category).filter(time=heat.time).order_by('extra', 'info')
+    # get all heats that match this time of day
+    parallel_heats = Heat.objects.filter(comp=heat.comp).filter(time=heat.time).order_by('heat_number', 'extra', 'info')
     heat_data = list()
 
     for h in parallel_heats:
@@ -42,54 +42,24 @@ def heat(request, heat_id):
         heat_data.append(next_item)
 
     comp_id = heat.comp_id
-    # determine how many different start times match this heat number (could be multiple if there are A or B heats with the same heat_number)
-    times = Heat.objects.filter(comp=heat.comp).filter(category=heat.category).filter(heat_number=heat.heat_number).datetimes('time', 'minute')
-    # if there's only one start time, use the heat number to determine next heat and previous heat
-    if len(times) == 1:
-        prev_heat = Heat.objects.filter(comp=heat.comp).filter(category=heat.category).filter(heat_number=heat.heat_number-1).first()
-        if prev_heat is not None:
-            prev_heat_id = prev_heat.id
-        else:
-            prev_heat_id = None
-        next_heat = Heat.objects.filter(comp=heat.comp).filter(category=heat.category).filter(heat_number=heat.heat_number+1).first()
-        if next_heat is not None:
-            next_heat_id = next_heat.id
-        else:
-            next_heat_id = None
-    else:
-        #print(times)
-        # heats at multiple start times for this heat number, search the list for the current heat being displayed
-        for index in range(len(times)):
-            if times[index] == heat.time:
-                print("Found " + str(heat.time))
-                if index == 0:
-                    # if the current heat is the earliest time, use the heat number to find the previous heat
-                    prev_heat = Heat.objects.filter(comp=heat.comp).filter(category=heat.category).filter(heat_number=heat.heat_number-1).first()
-                    if prev_heat is not None:
-                        prev_heat_id = prev_heat.id
-                    else:
-                        prev_heat_id = None
-                    # the next heat is found by looking at the next index of the time list
-                    next_heat_id = Heat.objects.filter(comp=heat.comp).filter(category=heat.category).filter(time=times[index+1]).first().id
-                elif index == len(times) - 1:
-                    # if the current heat is the latest time, the previous heat is found by looking at the previous index of the time list
-                    prev_heat_id = Heat.objects.filter(comp=heat.comp).filter(category=heat.category).filter(time=times[index-1]).first().id
-                    # the next heat is found by the heat number
-                    next_heat = Heat.objects.filter(comp=heat.comp).filter(category=heat.category).filter(heat_number=heat.heat_number+1).first()
-                    if next_heat is not None:
-                        next_heat_id = next_heat.id
-                    else:
-                        next_heat_id = None
-                else:
-                    # both previous and next heats are found by looking at the list of times
-                    #print(str(times[index-1]) + ' ' + str(times[index+1]))
-                    prev_heat_id = Heat.objects.filter(comp=heat.comp).filter(time=times[index-1]).first().id
-                    #print(prev_heat_id)
-                    next_heat_id = Heat.objects.filter(comp=heat.comp).filter(time=times[index+1]).first().id
-                    #print(next_heat_id)
-                break
-        else:  # shouldn't get here, but set both previous and next heat IDs to none
-            prev_heat_id = None
-            next_heat_id = None
+
+    # find the previous and next heats
+    prev_heat_id = None
+    prev_heat_time = None
+    next_heat_id = None
+    next_heat_time = None
+
+    comp_heats = Heat.objects.filter(comp=heat.comp)
+
+    for h in comp_heats:
+        if h.time > heat.time:
+            if next_heat_id is None or h.time < next_heat_time:
+                next_heat_id = h.pk
+                next_heat_time = h.time
+        elif h.time < heat.time:
+            if prev_heat_id is None or h.time > prev_heat_time:
+                prev_heat_id = h.pk
+                prev_heat_time = h.time
+
 
     return render(request, 'comps/heat.html', {'comp': heat.comp, 'heat_data': heat_data, 'prev_heat_id': prev_heat_id, 'next_heat_id': next_heat_id, 'show_edit_button': show_edit_button})


### PR DESCRIPTION
There may be different heat numbers on the floor at the same time. The items passed in to the Heat page are now all events starting at the same time. Next and Previous heats are based on start time, not heat number.