### PR TITLE
Don't process solos as multi-dance heats

### DIFF
--- a/comps/models/heat.py
+++ b/comps/models/heat.py
@@ -104,6 +104,8 @@ class Heat(models.Model):
     def multi_dance(self):
         '''This function returns True if the description indicates a multi-dance heat.'''
         s = self.info
+        if self.category in [Heat.SOLO, Heat.FORMATION]:
+            return False
         if "Solo Star" in s or "NP" in s:
             return False
         left_pos = s.find('(')

--- a/comps/scoresheet/ndca_prem_feed_results.py
+++ b/comps/scoresheet/ndca_prem_feed_results.py
@@ -66,6 +66,9 @@ class NdcaPremFeedResults(Results_Processor):
                     if r['Name'] == "Final":
                         # process final round results
                         self.entries_in_event = 0
+                        # don't process Solo - keep looking for heat_string
+                        if r['Scoring_Method'] == "Solos":
+                            continue
                         # loop through all the competitors in this heat
                         for c in r['Summary']['Competitors']:
                             self.entries_in_event += 1


### PR DESCRIPTION
Heat model discards solos and formations from being reported as multi-dance events.
ndca_premier_feed_results skips solo heats in scoresheet.