### PR TITLE
Update ndca_prem_feed_heatlist.py

### DIFF
--- a/comps/heatlist/ndca_prem_feed_heatlist.py
+++ b/comps/heatlist/ndca_prem_feed_heatlist.py
@@ -185,6 +185,9 @@ class NdcaPremFeedHeatlist(Heatlist):
         data = json.loads(response.text)
         print(len(data['Result']))
         for c in data['Result']:
+            if c['Type'] != 'Attendee':
+                print("Skipping: " + c['Type'] + ' ' + str(c['Name']))
+                continue;
             d = Heatlist_Dancer()
             d.load_from_ndca_premier_feed(c)
             d.comp = comp


### PR DESCRIPTION
'Team' participants had overlapping IDs with the individual 'Attendee' participants. Don't process 'Team' participants when loading dancers.