### PR TITLE
Iss 259 initial elo - part one

### DIFF
--- a/comps/models/heat.py
+++ b/comps/models/heat.py
@@ -3,7 +3,7 @@ from datetime import date, datetime, timezone, timedelta
 from django.db import models
 from comps.models.comp import Comp
 from rankings.models.couple import Couple
-from comps.scoresheet.calc_points import pro_heat_level, non_pro_heat_level
+from comps.scoresheet.calc_points import pro_heat_level, non_pro_heat_level, initial_elo_rating
 
 # the different styles of ballroom dancing. couples are ranked in each style.
 SMOOTH = "SMOO"
@@ -83,8 +83,11 @@ class Heat(models.Model):
     def set_level(self):
         if self.category == "PH":
             self.base_value = pro_heat_level(self.info)
+            self.initial_elo_value = initial_elo_rating(self.category, self.info)
         else:
             self.base_value = non_pro_heat_level(self.info, self.multi_dance())
+            if self.multi_dance():
+                self.initial_elo_value = initial_elo_rating(self.category, self.info)
 
     def remove_info_prefix(self):
         if self.info.startswith("L-"):

--- a/comps/tasks.py
+++ b/comps/tasks.py
@@ -225,7 +225,7 @@ def process_scoresheet_task(self, comp_data):
         else: # CompOrganizer for now
             scoresheet = CompOrgResults()
 
-        heats_to_process = Heat.objects.filter(comp=comp).order_by('time')
+        heats_to_process = Heat.objects.filter(comp=comp).order_by('initial_elo_value')
         num_heats = heats_to_process.count()
 
         index = 0


### PR DESCRIPTION
assign heat elo values earlier; process scoresheets in order of elo values in order to process Pro Rising Star heats before Open Pro heats in case a new couple enters both. 